### PR TITLE
Actualizo link al manual

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@ layout: landing
 								las dudas sobre la mecánica del juego.
 								</p>
 								<p>
-								El borrador del manual para equipos humanos puede <a href="https://drive.google.com/file/d/0B_Ea3BIVmBg5ajRuUDRZZXJOenNVbm44eU9MNkxpNjdlYmZj/view?usp=sharing">descargarse aquí</a>.
+								El borrador del manual para equipos humanos puede <a href="https://drive.google.com/file/d/0B_Ea3BIVmBg5Y3hpR3ZIdGxZMDA/view?usp=sharing">descargarse aquí</a>.
 								</p>
 							</div>
 						</section>


### PR DESCRIPTION
el que estaba era el Manual Humanos (prerelease), que tiene la nomenclatura vieja. No tiene Mega escuadrones / interceptores, por ejemplo. Se cambia por el v4 que está en la carpeta geekout.